### PR TITLE
Completed Syntax

### DIFF
--- a/src/Language/Spectacle/AST.hs
+++ b/src/Language/Spectacle/AST.hs
@@ -1,0 +1,29 @@
+module Language.Spectacle.AST
+  ( -- * Initial Actions
+    type Initial,
+    type InitialSyntax,
+
+    -- ** Interpreters
+    runInitial,
+
+    -- * Temporal Actions
+    type Action,
+    type ActionSyntax,
+
+    -- ** Interpreters
+    runAction,
+
+    -- * Invariants
+    type Invariant,
+    type InvariantSyntax,
+
+    -- ** Interpreters
+    runInvariant,
+  )
+where
+
+import Language.Spectacle.AST.Action (Action, ActionSyntax, runAction)
+import Language.Spectacle.AST.Initial (Initial, InitialSyntax, runInitial)
+import Language.Spectacle.AST.Invariant (Invariant, InvariantSyntax, runInvariant)
+
+-- ---------------------------------------------------------------------------------------------------------------------

--- a/src/Language/Spectacle/AST.hs
+++ b/src/Language/Spectacle/AST.hs
@@ -19,11 +19,22 @@ module Language.Spectacle.AST
 
     -- ** Interpreters
     runInvariant,
+
+    -- ** Rewriting
+    applyRewrites,
+
+    -- * Termination
+    type Terminate,
+    type TerminateSyntax,
+
+    -- ** Interpreters
+    runTerminate,
   )
 where
 
 import Language.Spectacle.AST.Action (Action, ActionSyntax, runAction)
 import Language.Spectacle.AST.Initial (Initial, InitialSyntax, runInitial)
-import Language.Spectacle.AST.Invariant (Invariant, InvariantSyntax, runInvariant)
+import Language.Spectacle.AST.Invariant (Invariant, InvariantSyntax, applyRewrites, runInvariant)
+import Language.Spectacle.AST.Terminate (Terminate, TerminateSyntax, runTerminate)
 
 -- ---------------------------------------------------------------------------------------------------------------------

--- a/src/Language/Spectacle/AST/Action/Internal.hs
+++ b/src/Language/Spectacle/AST/Action/Internal.hs
@@ -10,21 +10,23 @@ import GHC.TypeLits (Symbol)
 import Data.Type.Rec (Ascribe)
 import Language.Spectacle.Exception.RuntimeException (RuntimeException)
 import Language.Spectacle.Lang (EffectK, Lang)
-import Language.Spectacle.Syntax.Closure.Internal (Closure)
+import Language.Spectacle.Syntax.Closure.Internal (Closure, ClosureKind (ActionClosure))
 import Language.Spectacle.Syntax.Error.Internal (Error)
 import Language.Spectacle.Syntax.Logic.Internal (Logic)
 import Language.Spectacle.Syntax.NonDet.Internal (NonDet)
 import Language.Spectacle.Syntax.Plain.Internal (Plain)
 import Language.Spectacle.Syntax.Quantifier.Internal (Quantifier)
 
--- -------------------------------------------------------------------------------------------------
+-- ---------------------------------------------------------------------------------------------------------------------
 
 type Action :: [Ascribe Symbol Type] -> Type -> Type
-type Action ctx a = Lang ctx ActionSyntax a
+type Action ctx a = Lang ctx (ActionSyntax ctx) a
 
-type ActionSyntax :: [EffectK]
-type ActionSyntax =
-  '[ Closure
+type ActionSyntax :: [Ascribe Symbol Type] -> [EffectK]
+type ActionSyntax ctx =
+  -- NOTE: 'Closure' must be handled before 'Quantifier'. If 'Quantifier' discharged before 'Closure', erroneous values
+  -- are produced from any 'Closure' nested within a forall/exists.
+  '[ Closure 'ActionClosure
    , Quantifier
    , Logic
    , Plain

--- a/src/Language/Spectacle/AST/Initial.hs
+++ b/src/Language/Spectacle/AST/Initial.hs
@@ -51,7 +51,7 @@ import Language.Spectacle.Syntax.NonDet (NonDet, foldMapA, runNonDetA)
 
 -- ---------------------------------------------------------------------------------------------------------------------
 
--- | Runs an 'Initial' expression type, producing the initial values a model will can be checked from.
+-- | Runs an 'Initial' expression type, producing the initial values we can check a model with.
 --
 -- @since 0.1.0.0
 runInitial :: ReflectRow ctx => Initial ctx a -> Either RuntimeException [Rec ctx]

--- a/src/Language/Spectacle/AST/Initial.hs
+++ b/src/Language/Spectacle/AST/Initial.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE TupleSections #-}
+
+module Language.Spectacle.AST.Initial
+  ( -- * Initial State Syntax
+    type Initial,
+    type InitialSyntax,
+
+    -- ** Interpreters
+    runInitial,
+    runInitialClosure,
+  )
+where
+
+import Data.Coerce (coerce)
+import Data.Function ((&))
+import Data.Void (absurd)
+
+import Data.Functor.Loom (runLoom, weave, (~>~))
+import Data.Type.Rec
+  ( Rec,
+    RecT (RConT, RNil),
+    ReflectRow,
+    pattern RCon,
+  )
+import Language.Spectacle.AST.Initial.Internal
+  ( Initial,
+    InitialSyntax,
+    InitialValues (InitialValues),
+    emptyInitialValues,
+    initializeValue,
+  )
+import Language.Spectacle.Exception.RuntimeException
+  ( RuntimeException (VariableException),
+    VariableException (Uninitialized),
+  )
+import Language.Spectacle.Lang
+  ( Lang (Op, Pure, Scoped),
+    Member,
+    Members,
+    decomposeOp,
+    decomposeS,
+    runLang,
+  )
+import Language.Spectacle.Syntax.Closure
+  ( Closure (Closure),
+    ClosureKind (InitialClosure),
+    Effect (CloseInitial),
+  )
+import Language.Spectacle.Syntax.Error (Error, runError, throwE)
+import Language.Spectacle.Syntax.NonDet (NonDet, foldMapA, runNonDetA)
+
+-- ---------------------------------------------------------------------------------------------------------------------
+
+-- | Runs an 'Initial' expression type, producing the initial values a model will can be checked from.
+--
+-- @since 0.1.0.0
+runInitial :: ReflectRow ctx => Initial ctx a -> Either RuntimeException [Rec ctx]
+runInitial initialAction =
+  initialAction
+    & runInitialClosure emptyInitialValues
+    & (>>= \(rs, _) -> unpackInitials rs)
+    & runNonDetA
+    & runError
+    & runLang
+  where
+    unpackInitials ::
+      Members '[Error RuntimeException, NonDet] effs =>
+      InitialValues ctx' ->
+      Lang ctx effs (Rec ctx')
+    unpackInitials (InitialValues RNil) = return RNil
+    unpackInitials (InitialValues (RConT name value r)) = case value of
+      Nothing -> throwE (VariableException (Uninitialized (show name)))
+      Just x -> do
+        r' <- unpackInitials (InitialValues r)
+        return (RCon name x r')
+{-# INLINE runInitial #-}
+
+-- | Specialized interpreter which discharges a 'Closure' effect in an 'Initial' action.
+--
+-- @since 0.1.0.0
+runInitialClosure ::
+  Member NonDet effs =>
+  InitialValues ctx ->
+  Lang ctx (Closure 'InitialClosure ': effs) a ->
+  Lang ctx effs (InitialValues ctx, a)
+runInitialClosure initials = \case
+  Pure x -> pure (initials, x)
+  Op op k -> case decomposeOp op of
+    Left other -> Op other (runInitialClosure initials . k)
+    Right bottom -> absurd (coerce bottom)
+  Scoped scoped loom -> case decomposeS scoped of
+    Left other -> Scoped other (loom' initials)
+    Right (CloseInitial name expr) ->
+      let recs =
+            expr
+              & runNonDetA @[]
+              & runLang
+       in flip foldMapA recs \x ->
+            runLoom (loom' (initializeValue name x initials)) (pure ())
+    where
+      loom' initials' = loom ~>~ weave (initials', ()) (uncurry runInitialClosure)
+{-# INLINE runInitialClosure #-}

--- a/src/Language/Spectacle/AST/Initial/Internal.hs
+++ b/src/Language/Spectacle/AST/Initial/Internal.hs
@@ -1,0 +1,59 @@
+module Language.Spectacle.AST.Initial.Internal
+  ( -- * Initial State Syntax
+    type Initial,
+    type InitialSyntax,
+    InitialValues (InitialValues),
+    InitialValue (InitialValue),
+
+    -- * Internal State
+    emptyInitialValues,
+    initializeValue,
+  )
+where
+
+import Data.Kind (Type)
+import GHC.TypeLits (Symbol)
+
+import Data.Type.Rec
+  ( Ascribe,
+    HasSel (setRecT),
+    Name,
+    RecT,
+    ReflectRow (repeatRow),
+    type (#),
+    type (.|),
+  )
+import Language.Spectacle.Exception.RuntimeException ( RuntimeException )
+import Language.Spectacle.Lang (EffectK, Lang)
+import Language.Spectacle.Syntax.Closure.Internal ( Closure, ClosureKind(InitialClosure) )
+import Language.Spectacle.Syntax.Error.Internal (Error)
+import Language.Spectacle.Syntax.NonDet.Internal (NonDet)
+
+-- -------------------------------------------------------------------------------------------------
+
+type Initial :: [Ascribe Symbol Type] -> Type -> Type
+type Initial ctx a = Lang ctx InitialSyntax a
+
+type InitialSyntax :: [EffectK]
+type InitialSyntax = '[Closure 'InitialClosure, NonDet, Error RuntimeException]
+
+-- -------------------------------------------------------------------------------------------------
+
+newtype InitialValues :: [Ascribe Symbol Type] -> Type where
+  InitialValues :: RecT Maybe ctx -> InitialValues ctx
+
+newtype InitialValue a = InitialValue (Maybe a)
+
+-- | Constructs an empty 'InitialValues' filled with 'Nothing'.
+--
+-- @since 0.1.0.0
+emptyInitialValues :: ReflectRow ctx => InitialValues ctx
+emptyInitialValues = InitialValues (repeatRow Nothing)
+{-# INLINE emptyInitialValues #-}
+
+-- | Initializes the variable @'Name' s@ to the given value.
+--
+-- @since 0.1.0.0
+initializeValue :: s # a .| ctx => Name s -> a -> InitialValues ctx -> InitialValues ctx
+initializeValue name x (InitialValues r) = InitialValues (setRecT name (Just x) r)
+{-# INLINE initializeValue #-}

--- a/src/Language/Spectacle/AST/Initial/Internal.hs
+++ b/src/Language/Spectacle/AST/Initial/Internal.hs
@@ -23,9 +23,9 @@ import Data.Type.Rec
     type (#),
     type (.|),
   )
-import Language.Spectacle.Exception.RuntimeException ( RuntimeException )
+import Language.Spectacle.Exception.RuntimeException (RuntimeException)
 import Language.Spectacle.Lang (EffectK, Lang)
-import Language.Spectacle.Syntax.Closure.Internal ( Closure, ClosureKind(InitialClosure) )
+import Language.Spectacle.Syntax.Closure.Internal (Closure, ClosureKind (InitialClosure))
 import Language.Spectacle.Syntax.Error.Internal (Error)
 import Language.Spectacle.Syntax.NonDet.Internal (NonDet)
 

--- a/src/Language/Spectacle/AST/Invariant.hs
+++ b/src/Language/Spectacle/AST/Invariant.hs
@@ -1,0 +1,69 @@
+module Language.Spectacle.AST.Invariant
+  ( type Invariant,
+    type InvariantSyntax,
+    runInvariant,
+    applyRewrites,
+    getL4Terms,
+  )
+where
+
+import Data.Function ((&))
+
+import Data.Type.Rec (Rec)
+import Language.Spectacle.AST.Invariant.Internal
+  ( Invariant,
+    InvariantSyntax,
+  )
+import Language.Spectacle.Exception.RuntimeException (RuntimeException (SyntaxException))
+import Language.Spectacle.Lang (Lang, Member, runLang)
+import Language.Spectacle.Syntax.Error (Error, runError, throwE)
+import Language.Spectacle.Syntax.Fresh (Fresh, runFresh)
+import Language.Spectacle.Syntax.Logic (Logic)
+import Language.Spectacle.Syntax.Modal
+  ( LTerm,
+    Level (L4),
+    Modal,
+    Preterm,
+    SyntaxLevel (fromPreterm),
+    abstract,
+    materialize,
+    normalizePreterm,
+  )
+import Language.Spectacle.Syntax.Plain (runPlain)
+
+-- ---------------------------------------------------------------------------------------------------------------------
+
+-- | 'runInvariant' sends an 'Invariant' to its equivalent, reduced 'LTerm' representation.
+--
+-- @since 0.1.0.0
+runInvariant :: Rec ctx -> Invariant ctx Bool -> Either RuntimeException (LTerm 'L4 Bool)
+runInvariant st formula =
+  formula
+    & materialize
+    & (>>= getL4Terms)
+    & runPlain st
+    & runFresh 0
+    & runError
+    & runLang
+    & fmap snd
+{-# INLINE runInvariant #-}
+
+-- | Normalizes a temporal formula.
+--
+-- @since 0.1.0.0
+applyRewrites :: Member Fresh effs => Lang ctx (Modal ': Logic ': effs) Bool -> Lang ctx (Modal ': Logic ': effs) Bool
+applyRewrites formula =
+  formula
+    & materialize
+    & (>>= normalizePreterm)
+    & abstract
+{-# INLINE applyRewrites #-}
+
+-- | Sends 'Preterm' to 'LTerm' in a 'Lang'.
+--
+-- @since 0.1.0.0
+getL4Terms :: Member (Error RuntimeException) effs => Preterm Bool -> Lang ctx effs (LTerm 'L4 Bool)
+getL4Terms preterms = case fromPreterm @ 'L4 preterms of
+  Left exc -> throwE (SyntaxException exc)
+  Right lterms -> return lterms
+{-# INLINE getL4Terms #-}

--- a/src/Language/Spectacle/AST/Invariant.hs
+++ b/src/Language/Spectacle/AST/Invariant.hs
@@ -16,6 +16,7 @@ import Language.Spectacle.AST.Invariant.Internal
   )
 import Language.Spectacle.Exception.RuntimeException (RuntimeException (SyntaxException))
 import Language.Spectacle.Lang (Lang, Member, runLang)
+import Language.Spectacle.Syntax.Enabled (runEnabled)
 import Language.Spectacle.Syntax.Error (Error, runError, throwE)
 import Language.Spectacle.Syntax.Fresh (Fresh, runFresh)
 import Language.Spectacle.Syntax.Logic (Logic)
@@ -30,18 +31,21 @@ import Language.Spectacle.Syntax.Modal
     normalizePreterm,
   )
 import Language.Spectacle.Syntax.Plain (runPlain)
+import Language.Spectacle.Syntax.Prime (substPrime)
 
 -- ---------------------------------------------------------------------------------------------------------------------
 
 -- | 'runInvariant' sends an 'Invariant' to its equivalent, reduced 'LTerm' representation.
 --
 -- @since 0.1.0.0
-runInvariant :: Rec ctx -> Invariant ctx Bool -> Either RuntimeException (LTerm 'L4 Bool)
-runInvariant st formula =
+runInvariant :: Bool -> Rec ctx -> Rec ctx -> Invariant ctx Bool -> Either RuntimeException (LTerm 'L4 Bool)
+runInvariant isEnabled worldHere worldThere formula =
   formula
     & materialize
     & (>>= getL4Terms)
-    & runPlain st
+    & runEnabled isEnabled
+    & substPrime worldThere
+    & runPlain worldHere
     & runFresh 0
     & runError
     & runLang

--- a/src/Language/Spectacle/AST/Invariant/Internal.hs
+++ b/src/Language/Spectacle/AST/Invariant/Internal.hs
@@ -10,11 +10,13 @@ import GHC.TypeLits (Symbol)
 import Data.Type.Rec (Ascribe)
 import Language.Spectacle.Exception.RuntimeException (RuntimeException)
 import Language.Spectacle.Lang (EffectK, Lang)
+import Language.Spectacle.Syntax.Enabled.Internal (Enabled)
 import Language.Spectacle.Syntax.Error.Internal (Error)
 import Language.Spectacle.Syntax.Fresh.Internal (Fresh)
 import Language.Spectacle.Syntax.Logic.Internal (Logic)
 import Language.Spectacle.Syntax.Modal.Internal (Modal)
 import Language.Spectacle.Syntax.Plain.Internal (Plain)
+import Language.Spectacle.Syntax.Prime.Internal (Prime)
 
 -- -------------------------------------------------------------------------------------------------
 
@@ -25,6 +27,8 @@ type InvariantSyntax :: [Ascribe Symbol Type] -> [EffectK]
 type InvariantSyntax ctx =
   '[ Modal
    , Logic
+   , Enabled
+   , Prime
    , Plain
    , Fresh
    , Error RuntimeException

--- a/src/Language/Spectacle/AST/Invariant/Internal.hs
+++ b/src/Language/Spectacle/AST/Invariant/Internal.hs
@@ -1,0 +1,34 @@
+module Language.Spectacle.AST.Invariant.Internal
+  ( type Invariant,
+    type InvariantSyntax,
+  )
+where
+
+import Data.Kind (Type)
+import GHC.TypeLits (Symbol)
+
+import Data.Type.Rec
+import Language.Spectacle.Exception.RuntimeException
+import Language.Spectacle.Lang
+import Language.Spectacle.Syntax.Error.Internal
+import Language.Spectacle.Syntax.Logic.Internal
+import Language.Spectacle.Syntax.Modal.Graded
+import Language.Spectacle.Syntax.Modal.Internal
+import Language.Spectacle.Syntax.Modal.Preterm
+import Language.Spectacle.Syntax.Plain.Internal
+import Language.Spectacle.Syntax.Prime.Internal
+import Language.Spectacle.Syntax.Fresh.Internal
+
+-- -------------------------------------------------------------------------------------------------
+
+type Invariant :: [Ascribe Symbol Type] -> Type -> Type
+type Invariant ctx a = Lang ctx (InvariantSyntax ctx) a
+
+type InvariantSyntax :: [Ascribe Symbol Type] -> [EffectK]
+type InvariantSyntax ctx =
+  '[ Modal
+   , Logic
+   , Plain 
+   , Fresh
+   , Error RuntimeException
+   ]

--- a/src/Language/Spectacle/AST/Invariant/Internal.hs
+++ b/src/Language/Spectacle/AST/Invariant/Internal.hs
@@ -7,17 +7,14 @@ where
 import Data.Kind (Type)
 import GHC.TypeLits (Symbol)
 
-import Data.Type.Rec
-import Language.Spectacle.Exception.RuntimeException
-import Language.Spectacle.Lang
-import Language.Spectacle.Syntax.Error.Internal
-import Language.Spectacle.Syntax.Logic.Internal
-import Language.Spectacle.Syntax.Modal.Graded
-import Language.Spectacle.Syntax.Modal.Internal
-import Language.Spectacle.Syntax.Modal.Preterm
-import Language.Spectacle.Syntax.Plain.Internal
-import Language.Spectacle.Syntax.Prime.Internal
-import Language.Spectacle.Syntax.Fresh.Internal
+import Data.Type.Rec (Ascribe)
+import Language.Spectacle.Exception.RuntimeException (RuntimeException)
+import Language.Spectacle.Lang (EffectK, Lang)
+import Language.Spectacle.Syntax.Error.Internal (Error)
+import Language.Spectacle.Syntax.Fresh.Internal (Fresh)
+import Language.Spectacle.Syntax.Logic.Internal (Logic)
+import Language.Spectacle.Syntax.Modal.Internal (Modal)
+import Language.Spectacle.Syntax.Plain.Internal (Plain)
 
 -- -------------------------------------------------------------------------------------------------
 
@@ -28,7 +25,7 @@ type InvariantSyntax :: [Ascribe Symbol Type] -> [EffectK]
 type InvariantSyntax ctx =
   '[ Modal
    , Logic
-   , Plain 
+   , Plain
    , Fresh
    , Error RuntimeException
    ]

--- a/src/Language/Spectacle/AST/Terminate.hs
+++ b/src/Language/Spectacle/AST/Terminate.hs
@@ -1,0 +1,27 @@
+module Language.Spectacle.AST.Terminate
+  ( -- * Termination Condition Syntax
+    type Terminate,
+    type TerminateSyntax,
+
+    -- ** Interpreters
+    runTerminate,
+  )
+where
+
+import Data.Function ((&))
+
+import Data.Type.Rec (Rec)
+import Language.Spectacle.AST.Terminate.Internal (Terminate, TerminateSyntax)
+import Language.Spectacle.Lang (runLang)
+import Language.Spectacle.Syntax.Enabled (runEnabled)
+import Language.Spectacle.Syntax.Plain (runPlain)
+
+-- ---------------------------------------------------------------------------------------------------------------------
+
+runTerminate :: Bool -> Rec ctx -> Terminate ctx Bool -> Bool
+runTerminate isEnabled knowns termination =
+  termination
+    & runPlain knowns
+    & runEnabled isEnabled
+    & runLang
+{-# INLINE runTerminate #-}

--- a/src/Language/Spectacle/AST/Terminate/Internal.hs
+++ b/src/Language/Spectacle/AST/Terminate/Internal.hs
@@ -1,0 +1,25 @@
+module Language.Spectacle.AST.Terminate.Internal
+  ( -- * Termination Condition Syntax
+    type Terminate,
+    type TerminateSyntax,
+  )
+where
+
+import Data.Kind (Type)
+import GHC.TypeLits (Symbol)
+
+import Data.Type.Rec (Ascribe)
+import Language.Spectacle.Lang (EffectK, Lang)
+import Language.Spectacle.Syntax.Enabled.Internal (Enabled)
+import Language.Spectacle.Syntax.Plain.Internal (Plain)
+
+-- ---------------------------------------------------------------------------------------------------------------------
+
+type Terminate :: [Ascribe Symbol Type] -> Type -> Type
+type Terminate ctx a = Lang ctx TerminateSyntax a
+
+type TerminateSyntax :: [EffectK]
+type TerminateSyntax =
+  '[ Plain
+   , Enabled
+   ]

--- a/src/Language/Spectacle/Exception/RuntimeException.hs
+++ b/src/Language/Spectacle/Exception/RuntimeException.hs
@@ -1,30 +1,39 @@
 {-# LANGUAGE DeriveAnyClass #-}
 
 module Language.Spectacle.Exception.RuntimeException
-  ( RuntimeException (VariableException, QuantifierException),
-    VariableException (CyclicReference),
-    QuantifierException (ForallViolated, ExistsViolated)
+  ( RuntimeException (VariableException, QuantifierException, SyntaxException),
+    VariableException (CyclicReference, Uninitialized),
+    QuantifierException (ForallViolated, ExistsViolated),
+    SyntaxException (LevelMismatch, ComplementInL3),
   )
 where
 
 import Control.Exception (Exception)
 import Type.Reflection (Typeable)
 
--- -------------------------------------------------------------------------------------------------
+-- ---------------------------------------------------------------------------------------------------------------------
 
 data RuntimeException where
   VariableException :: VariableException -> RuntimeException
   QuantifierException :: QuantifierException -> RuntimeException
+  SyntaxException :: SyntaxException -> RuntimeException
   deriving stock (Show, Typeable)
   deriving anyclass Exception
 
 data VariableException where
   CyclicReference :: [String] -> VariableException
+  Uninitialized :: String -> VariableException
   deriving stock (Show, Typeable)
   deriving anyclass Exception
 
 data QuantifierException where
   ForallViolated :: QuantifierException
   ExistsViolated :: QuantifierException
+  deriving stock (Show, Typeable)
+  deriving anyclass Exception
+
+data SyntaxException where
+  LevelMismatch :: Int -> [Int] -> SyntaxException
+  ComplementInL3 :: SyntaxException
   deriving stock (Show, Typeable)
   deriving anyclass Exception

--- a/src/Language/Spectacle/RTS/Registers.hs
+++ b/src/Language/Spectacle/RTS/Registers.hs
@@ -32,10 +32,10 @@ import Language.Spectacle.Syntax.Prime.Internal (Prime)
 -- ---------------------------------------------------------------------------------------------------------------------
 
 type RelationTerm :: [Ascribe Symbol Type] -> Type -> Type
-type RelationTerm ctx a = Lang ctx RelationTermSyntax a
+type RelationTerm ctx a = Lang ctx (RelationTermSyntax ctx) a
 
-type RelationTermSyntax :: [EffectK]
-type RelationTermSyntax = '[Prime, Plain, NonDet, Error RuntimeException]
+type RelationTermSyntax :: [Ascribe Symbol Type] -> [EffectK]
+type RelationTermSyntax ctx = '[Prime, Plain, NonDet, Error RuntimeException]
 
 -- | Internal state used by variable substitution and variable relations.
 --
@@ -93,7 +93,7 @@ setRegister n x (Registers rs) = Registers (setRecT n (Evaluated x) rs)
 -- | Sets the value of the variable named @s@ in 'Registers' to an unevaluated expression.
 --
 -- @since 0.1.0.0
-setThunk :: s # a .| ctx => Name s -> Lang ctx RelationTermSyntax a -> Registers ctx -> Registers ctx
+setThunk :: s # a .| ctx => Name s -> RelationTerm ctx a -> Registers ctx -> Registers ctx
 setThunk n m (Registers rs) = Registers (setRecT n (Thunk m) rs)
 
 -- | A 'Thunk' is the state of a primed variable in @ctx@.
@@ -104,7 +104,7 @@ setThunk n m (Registers rs) = Registers (setRecT n (Thunk m) rs)
 --
 -- @since 0.1.0.0
 data Thunk ctx a
-  = Thunk (Lang ctx RelationTermSyntax a)
+  = Thunk (Lang ctx (RelationTermSyntax ctx) a)
   | Evaluated a
   | Unchanged
 

--- a/src/Language/Spectacle/Syntax.hs
+++ b/src/Language/Spectacle/Syntax.hs
@@ -1,0 +1,71 @@
+module Language.Spectacle.Syntax
+  ( -- * Closures
+    define,
+    (.=),
+
+    -- * Errors
+    catchE,
+    throwE,
+
+    -- * Logic
+    conjunct,
+    (/\),
+    disjunct,
+    (\/),
+    complement,
+    (==>),
+    implies,
+    (<=>),
+    iff,
+
+    -- * Modal Operators
+    always,
+    eventually,
+    upUntil,
+
+    -- * Nondeterminism
+    oneOf,
+
+    -- * Variables
+    plain,
+    prime,
+
+    -- * Quantifiers
+    forall,
+    exists,
+
+    -- * Enabled
+    enabled,
+  )
+where
+
+import Language.Spectacle.Lang (Lang, Member)
+import Language.Spectacle.Syntax.Closure (define, (.=))
+import Language.Spectacle.Syntax.Enabled (enabled)
+import Language.Spectacle.Syntax.Error (catchE, throwE)
+import Language.Spectacle.Syntax.Logic (Logic, complement, conjunct, disjunct, iff, implies)
+import Language.Spectacle.Syntax.Modal (always, eventually, upUntil)
+import Language.Spectacle.Syntax.NonDet (oneOf)
+import Language.Spectacle.Syntax.Plain (plain)
+import Language.Spectacle.Syntax.Prime (prime)
+import Language.Spectacle.Syntax.Quantifier (exists, forall)
+
+-- ---------------------------------------------------------------------------------------------------------------------
+
+infixl 5 /\
+(/\) :: Member Logic effs => Lang ctx effs Bool -> Lang ctx effs Bool -> Lang ctx effs Bool
+(/\) = conjunct
+{-# INLINE (/\) #-}
+
+infixl 5 \/
+(\/) :: Member Logic effs => Lang ctx effs Bool -> Lang ctx effs Bool -> Lang ctx effs Bool
+(\/) = disjunct
+{-# INLINE (\/) #-}
+
+(==>) :: Member Logic effs => Lang ctx effs Bool -> Lang ctx effs Bool -> Lang ctx effs Bool
+(==>) = implies
+{-# INLINE (==>) #-}
+
+(<=>) :: Member Logic effs => Lang ctx effs Bool -> Lang ctx effs Bool -> Lang ctx effs Bool
+(<=>) = iff
+{-# INLINE (<=>) #-}

--- a/src/Language/Spectacle/Syntax/Closure.hs
+++ b/src/Language/Spectacle/Syntax/Closure.hs
@@ -45,6 +45,9 @@ import Language.Spectacle.Syntax.Prime (RuntimeState (primes), substitute)
 
 -- ---------------------------------------------------------------------------------------------------------------------
 
+-- | A synonym for ('.=') which can only be used in initial actions.
+--
+-- @since 0.1.0.0
 define ::
   (s # a .| ctx, Member (Closure 'InitialClosure) effs') =>
   Name s ->
@@ -53,6 +56,20 @@ define ::
 define name expr = scope (CloseInitial name expr)
 {-# INLINE define #-}
 
+-- | The ('.=') operator relates the variable @s@ to the primed values it can access in the next temporal frame. For
+-- example, a relation which increments a variable named "x" with any number 1 through 5 each frame of time would be
+-- written as:
+--
+-- @
+-- increment :: Action IncrementSpec Bool
+-- increment = do
+--   x <- plain #x -- retrieve the value of "x" from the previous frame
+--   exists [1 .. 5] \n -> do
+--     #x .= return (x + n) -- set the value of "x" in the next value to x + n for some number 1 <= n <= 5
+--     return True -- relate the value to the next frame, @return (odd n)@ could be written to exclude even n.
+-- @
+--
+-- @since 0.1.0.0
 (.=) ::
   (s # a .| ctx, Member (Closure 'ActionClosure) effs') =>
   Name s ->

--- a/src/Language/Spectacle/Syntax/Closure.hs
+++ b/src/Language/Spectacle/Syntax/Closure.hs
@@ -1,14 +1,13 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE RecordWildCards #-}
-
 -- | Closures and variable relations.
 --
 -- @since 0.1.0.0
 module Language.Spectacle.Syntax.Closure
-  ( Closure (Closure),
-    Effect (Close),
+  ( ClosureKind (ActionClosure, InitialClosure),
+    Closure (Closure),
+    Effect (CloseAction, CloseInitial),
+    define,
     (.=),
-    runClosure,
+    runActionClosure,
   )
 where
 
@@ -34,7 +33,11 @@ import Language.Spectacle.RTS.Registers
     getRegister,
     setThunk,
   )
-import Language.Spectacle.Syntax.Closure.Internal (Closure (Closure), Effect (Close))
+import Language.Spectacle.Syntax.Closure.Internal
+  ( Closure (Closure),
+    ClosureKind (ActionClosure, InitialClosure),
+    Effect (CloseAction, CloseInitial),
+  )
 import Language.Spectacle.Syntax.Env (Env, gets, modify)
 import Language.Spectacle.Syntax.Error (Error)
 import Language.Spectacle.Syntax.NonDet (NonDet)
@@ -42,28 +45,39 @@ import Language.Spectacle.Syntax.Prime (RuntimeState (primes), substitute)
 
 -- ---------------------------------------------------------------------------------------------------------------------
 
--- | Determines the value of a primed value in the next time frame. The following example allows for
--- the new value of "x" to be any 'Int' in the range @[1 .. 5]@.
---
--- >>> #x .= oneOf [1 :: Int .. 5 :: Int]
--- >>> prime #x
---
--- @since 0.1.0.0
-(.=) :: (s # a .| ctx, Member Closure effs) => Name s -> RelationTerm ctx a -> Lang ctx effs ()
-name .= expr = scope (Close name expr)
+define ::
+  (s # a .| ctx, Member (Closure 'InitialClosure) effs') =>
+  Name s ->
+  Lang ctx '[NonDet] a ->
+  Lang ctx effs' ()
+define name expr = scope (CloseInitial name expr)
+{-# INLINE define #-}
+
+(.=) ::
+  (s # a .| ctx, Member (Closure 'ActionClosure) effs') =>
+  Name s ->
+  RelationTerm ctx a ->
+  Lang ctx effs' ()
+name .= expr = scope (CloseAction name expr)
 {-# INLINE (.=) #-}
 
 -- | Discharges a 'Closure' effect, returning a 'Rec' new values for each variable in @ctx@.
 --
 -- @since 0.1.0.0
-runClosure :: Members '[NonDet, Env, Error RuntimeException] effs => Lang ctx (Closure ': effs) a -> Lang ctx effs a
-runClosure m = evaluateThunks (makeThunks m)
-{-# INLINE runClosure #-}
+runActionClosure ::
+  Members '[NonDet, Env, Error RuntimeException] effs =>
+  Lang ctx (Closure 'ActionClosure ': effs) a ->
+  Lang ctx effs a
+runActionClosure m = evaluateThunks (makeThunks m)
+{-# INLINE runActionClosure #-}
 
 -- | Evaluates all unevaluated closures in a specification.
 --
 -- @since 0.1.0.0
-evaluateThunks :: Members '[NonDet, Env, Error RuntimeException] effs => Lang ctx (Closure ': effs) a -> Lang ctx effs a
+evaluateThunks ::
+  Members '[NonDet, Env, Error RuntimeException] effs =>
+  Lang ctx (Closure 'ActionClosure ': effs) a ->
+  Lang ctx effs a
 evaluateThunks = \case
   Pure x -> pure x
   Op op k -> case decomposeOp op of
@@ -73,7 +87,7 @@ evaluateThunks = \case
       k' = evaluateThunks . k
   Scoped scoped loom -> case decomposeS scoped of
     Left other -> Scoped other loom'
-    Right (Close name _) ->
+    Right (CloseAction name _) ->
       gets (getRegister name . primes) >>= \case
         Thunk expr -> do
           x <- substitute name expr
@@ -91,20 +105,23 @@ evaluateThunks = \case
 -- primed variables takes place.
 --
 -- @since 0.1.0.0
-makeThunks :: Members '[Closure, Env, Error RuntimeException] effs => Lang ctx effs a -> Lang ctx effs a
+makeThunks ::
+  Members '[Closure 'ActionClosure, Env, Error RuntimeException] effs =>
+  Lang ctx effs a ->
+  Lang ctx effs a
 makeThunks = \case
   Pure x -> pure x
   Op op k -> case project op of
     Nothing -> Op op k'
-    Just (Closure bottom) -> absurd bottom
+    Just (Closure bottom :: Closure 'ActionClosure x) -> absurd bottom
     where
       k' = makeThunks . k
   Scoped scoped loom -> case projectS scoped of
     Nothing -> Scoped scoped loom'
-    Just (Close name expr) -> do
+    Just (CloseAction name expr) -> do
       x <- runLoom loom' (pure ())
       modify \rtst -> rtst {primes = setThunk name expr (primes rtst)}
-      scope (Close name expr)
+      scope (CloseAction name expr)
       return x
     where
       loom' = loom ~>~ hoist makeThunks

--- a/src/Language/Spectacle/Syntax/Enabled.hs
+++ b/src/Language/Spectacle/Syntax/Enabled.hs
@@ -1,0 +1,40 @@
+module Language.Spectacle.Syntax.Enabled
+  ( -- * Labels
+    Enabled (Enabled),
+    Effect (EnabledS),
+    enabled,
+
+    -- ** Interpreters
+    runEnabled,
+  )
+where
+
+import Data.Void (absurd)
+
+import Data.Functor.Loom (hoist, (~>~))
+import Language.Spectacle.Lang
+  ( Effect,
+    Lang (Op, Pure, Scoped),
+    Member,
+    decomposeOp,
+    decomposeS,
+    send,
+  )
+import Language.Spectacle.Syntax.Enabled.Internal (Effect (EnabledS), Enabled (Enabled))
+
+-- ---------------------------------------------------------------------------------------------------------------------
+
+enabled :: Member Enabled effs => Lang ctx effs Bool
+enabled = send Enabled
+{-# INLINE enabled #-}
+
+runEnabled :: Bool -> Lang ctx (Enabled : effs) a -> Lang ctx effs a
+runEnabled isEnabled = \case
+  Pure x -> pure x
+  Op op k -> case decomposeOp op of
+    Left other -> Op other (runEnabled isEnabled . k)
+    Right Enabled -> runEnabled isEnabled (k isEnabled)
+  Scoped scoped loom -> case decomposeS scoped of
+    Left other -> Scoped other (loom ~>~ hoist (runEnabled isEnabled))
+    Right (EnabledS bottom) -> absurd bottom
+{-# INLINE runEnabled #-}

--- a/src/Language/Spectacle/Syntax/Enabled/Internal.hs
+++ b/src/Language/Spectacle/Syntax/Enabled/Internal.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE TypeFamilies #-}
+
+module Language.Spectacle.Syntax.Enabled.Internal
+  ( Enabled (Enabled),
+    Effect (EnabledS),
+  )
+where
+
+import Data.Void (Void)
+
+import Language.Spectacle.Lang (Effect, EffectK, Lang, ScopeK)
+
+-- ---------------------------------------------------------------------------------------------------------------------
+
+data Enabled :: EffectK where
+  Enabled :: Enabled Bool
+
+newtype instance Effect Enabled :: ScopeK where
+  EnabledS :: Void -> Effect Enabled m a

--- a/src/Language/Spectacle/Syntax/Logic.hs
+++ b/src/Language/Spectacle/Syntax/Logic.hs
@@ -59,7 +59,7 @@ disjunct m n = scope (Disjunct m n)
 --
 -- @since 0.1.0.0
 implies :: Member Logic effs => Lang ctx effs Bool -> Lang ctx effs Bool -> Lang ctx effs Bool
-implies m n = complement (conjunct m (complement n))
+implies m n = disjunct (complement m) n
 {-# INLINE implies #-}
 
 -- | If and only if.

--- a/src/Language/Spectacle/Syntax/Modal.hs
+++ b/src/Language/Spectacle/Syntax/Modal.hs
@@ -10,12 +10,99 @@ module Language.Spectacle.Syntax.Modal
     always,
     eventually,
     upUntil,
+
+    -- * Leveled Syntax
+    LTerm
+      ( ValueL1,
+        EmbedL1,
+        ConjunctL2,
+        DisjunctL2,
+        ComplementL2,
+        ImpliesL2,
+        NotImpliesL2,
+        AlwaysL3,
+        EventuallyL3,
+        UpUntilL3,
+        ModalL4,
+        ConjunctL4,
+        DisjunctL4
+      ),
+
+    -- ** Syntactic Levels
+    SyntaxLevel (fromPreterm),
+    Level (L1, L2, L3, L4),
+    levelMismatch,
+    levelsAsNums,
+    fromLevel,
+    levelsOf,
+    nameFromL3,
+
+    -- * Preterms
+    Preterm
+      ( PreConst,
+        PreConjunct,
+        PreDisjunct,
+        PreImplies,
+        PreNotImplies,
+        PreComplement,
+        PreAlways,
+        PreUpUntil
+      ),
+    pattern PreEventually,
+    materialize,
+    abstract,
+    normalizePreterm,
+    rewritePreterm,
   )
 where
 
 import Language.Spectacle.Lang (Effect, Lang, Members, scope)
 import Language.Spectacle.Syntax.Fresh (Fresh, fresh)
-import Language.Spectacle.Syntax.Modal.Internal (Effect (Always, UpUntil), Modal (Modal))
+import Language.Spectacle.Syntax.Modal.Graded
+  ( LTerm
+      ( AlwaysL3,
+        ComplementL2,
+        ConjunctL2,
+        ConjunctL4,
+        DisjunctL2,
+        DisjunctL4,
+        EmbedL1,
+        EventuallyL3,
+        ImpliesL2,
+        ModalL4,
+        NotImpliesL2,
+        UpUntilL3,
+        ValueL1
+      ),
+    Level (L1, L2, L3, L4),
+    SyntaxLevel (fromPreterm),
+    fromLevel,
+    levelMismatch,
+    levelsAsNums,
+    levelsOf,
+    nameFromL3,
+  )
+import Language.Spectacle.Syntax.Modal.Internal
+  ( Effect (Always, UpUntil),
+    Modal (Modal),
+  )
+import Language.Spectacle.Syntax.Modal.Preterm
+  ( Preterm
+      ( PreAlways,
+        PreComplement,
+        PreConjunct,
+        PreConst,
+        PreDisjunct,
+        PreUpUntil
+      ),
+    abstract,
+    materialize,
+    normalizePreterm,
+    rewritePreterm,
+    pattern PreEventually,
+    pattern PreImplies,
+    pattern PreNotImplies,
+  )
 
 -- ---------------------------------------------------------------------------------------------------------------------
 

--- a/src/Language/Spectacle/Syntax/Modal.hs
+++ b/src/Language/Spectacle/Syntax/Modal.hs
@@ -23,6 +23,8 @@ module Language.Spectacle.Syntax.Modal
         AlwaysL3,
         EventuallyL3,
         UpUntilL3,
+        InfinitelyOftenL3,
+        StaysAsL3,
         ModalL4,
         ConjunctL4,
         DisjunctL4
@@ -69,8 +71,10 @@ import Language.Spectacle.Syntax.Modal.Graded
         EmbedL1,
         EventuallyL3,
         ImpliesL2,
+        InfinitelyOftenL3,
         ModalL4,
         NotImpliesL2,
+        StaysAsL3,
         UpUntilL3,
         ValueL1
       ),

--- a/src/Language/Spectacle/Syntax/Modal/Graded.hs
+++ b/src/Language/Spectacle/Syntax/Modal/Graded.hs
@@ -22,6 +22,8 @@ module Language.Spectacle.Syntax.Modal.Graded
         AlwaysL3,
         EventuallyL3,
         UpUntilL3,
+        InfinitelyOftenL3,
+        StaysAsL3,
         ModalL4,
         ConjunctL4,
         DisjunctL4
@@ -92,7 +94,13 @@ instance SyntaxLevel 'L2 where
 
   fromPreterm = \case
     PreConst x -> return (EmbedL1 (ValueL1 x))
-    PreImplies lhs rhs -> ImpliesL2 <$> fromPreterm lhs <*> fromPreterm rhs
+    PreImplies lhs rhs
+      | PreAlways {} <- rhs -> ImpliesL2 <$> fromPreterm lhs <*> fromPreterm rhs
+      | PreUpUntil {} <- rhs -> ImpliesL2 <$> fromPreterm lhs <*> fromPreterm rhs
+      | otherwise -> do
+          lhs' <- fromPreterm lhs
+          rhs' <- fromPreterm rhs
+          return (DisjunctL2 (ComplementL2 lhs') rhs')
     PreNotImplies lhs rhs -> NotImpliesL2 <$> fromPreterm lhs <*> fromPreterm rhs
     PreConjunct lhs rhs -> ConjunctL2 <$> fromPreterm lhs <*> fromPreterm rhs
     PreDisjunct lhs rhs -> DisjunctL2 <$> fromPreterm lhs <*> fromPreterm rhs

--- a/src/Language/Spectacle/Syntax/Modal/Graded.hs
+++ b/src/Language/Spectacle/Syntax/Modal/Graded.hs
@@ -53,7 +53,7 @@ import Language.Spectacle.Syntax.Modal.Preterm
 -- @since 0.1.0.0
 data Level = L1 | L2 | L3 | L4
 
--- | Class of syntactic levels that 'Preterm' can be converted into.
+-- | The class of representations for well-formed temporal formula.
 --
 -- @since 0.1.0.0
 type SyntaxLevel :: Level -> Constraint
@@ -113,8 +113,7 @@ instance SyntaxLevel 'L3 where
   fromPreterm = \case
     PreComplement {} ->
       -- At the level of modal expressions complement/negation is valid; however, it should be factored by the dual laws
-      -- and distributive laws so we rebuild the expression in rewriting preterms. We could rebuild the expression,
-      -- rewrite, and try again but this is a questionable approach since complement should be here in the first place.
+      -- and distributive laws when preterms are rewritten.
       Left ComplementInL3
     PreEventually name terms
       | PreAlways _ terms' <- terms -> StaysAsL3 name <$> fromPreterm @ 'L2 terms'

--- a/src/Language/Spectacle/Syntax/Modal/Graded.hs
+++ b/src/Language/Spectacle/Syntax/Modal/Graded.hs
@@ -1,0 +1,194 @@
+{-# LANGUAGE TypeFamilies #-}
+
+module Language.Spectacle.Syntax.Modal.Graded
+  ( -- * Syntactic Levels
+    Level (L1, L2, L3, L4),
+    levelMismatch,
+    levelsAsNums,
+    fromLevel,
+    levelsOf,
+    nameFromL3,
+
+    -- ** Construction
+    SyntaxLevel (fromPreterm),
+    LTerm
+      ( ValueL1,
+        EmbedL1,
+        ConjunctL2,
+        DisjunctL2,
+        ComplementL2,
+        ImpliesL2,
+        NotImpliesL2,
+        AlwaysL3,
+        EventuallyL3,
+        UpUntilL3,
+        ModalL4,
+        ConjunctL4,
+        DisjunctL4
+      ),
+  )
+where
+
+import Data.Kind (Constraint, Type)
+
+import Language.Spectacle.Exception.RuntimeException (SyntaxException (ComplementInL3, LevelMismatch))
+import Language.Spectacle.Syntax.Modal.Preterm
+  ( Preterm
+      ( PreAlways,
+        PreComplement,
+        PreConjunct,
+        PreConst,
+        PreDisjunct,
+        PreUpUntil
+      ),
+    pattern PreEventually,
+    pattern PreImplies,
+    pattern PreNotImplies,
+  )
+
+-- ---------------------------------------------------------------------------------------------------------------------
+
+-- | An enumeration of syntactic levels for temporal formula.
+--
+-- @since 0.1.0.0
+data Level = L1 | L2 | L3 | L4
+
+-- | Class of syntactic levels that 'Preterm' can be converted into.
+--
+-- @since 0.1.0.0
+type SyntaxLevel :: Level -> Constraint
+class SyntaxLevel n where
+  -- | 'LTerm' is a leveled (or graded) term. It is a 'Preterm' along with a type-level grading that constrains the
+  -- structure of the AST such that only valid TLA formula are representable in 'LTerm'.
+  --
+  -- @since 0.1.0.0
+  data LTerm n :: Type -> Type
+
+  -- | Sends a possibly malformed 'Preterm' to an equivalent 'LTerm'.
+  --
+  -- @since 0.1.0.0
+  fromPreterm :: Preterm Bool -> Either SyntaxException (LTerm n Bool)
+
+-- | @since 0.1.0.0
+instance SyntaxLevel 'L1 where
+  data LTerm 'L1 a where
+    ValueL1 :: a -> LTerm 'L1 a
+    deriving (Show)
+
+  fromPreterm (PreConst x) = return (ValueL1 x)
+  fromPreterm term = Left (levelMismatch 0 term)
+  {-# INLINE CONLIKE fromPreterm #-}
+
+-- | @since 0.1.0.0
+instance SyntaxLevel 'L2 where
+  data LTerm 'L2 a where
+    EmbedL1 :: LTerm 'L1 a -> LTerm 'L2 a
+    ConjunctL2 :: LTerm 'L2 a -> LTerm 'L2 a -> LTerm 'L2 a
+    DisjunctL2 :: LTerm 'L2 a -> LTerm 'L2 a -> LTerm 'L2 a
+    ComplementL2 :: LTerm 'L2 a -> LTerm 'L2 a
+    ImpliesL2 :: LTerm 'L2 a -> LTerm 'L3 a -> LTerm 'L2 a
+    NotImpliesL2 :: LTerm 'L2 a -> LTerm 'L3 a -> LTerm 'L2 a
+    deriving (Show)
+
+  fromPreterm = \case
+    PreConst x -> return (EmbedL1 (ValueL1 x))
+    PreImplies lhs rhs -> ImpliesL2 <$> fromPreterm lhs <*> fromPreterm rhs
+    PreNotImplies lhs rhs -> NotImpliesL2 <$> fromPreterm lhs <*> fromPreterm rhs
+    PreConjunct lhs rhs -> ConjunctL2 <$> fromPreterm lhs <*> fromPreterm rhs
+    PreDisjunct lhs rhs -> DisjunctL2 <$> fromPreterm lhs <*> fromPreterm rhs
+    PreComplement terms -> ComplementL2 <$> fromPreterm terms
+    terms -> Left (levelMismatch 2 terms)
+  {-# INLINE fromPreterm #-}
+
+-- | @since 0.1.0.0
+instance SyntaxLevel 'L3 where
+  data LTerm 'L3 a where
+    AlwaysL3 :: Int -> LTerm 'L2 a -> LTerm 'L3 a
+    EventuallyL3 :: Int -> LTerm 'L2 a -> LTerm 'L3 a
+    UpUntilL3 :: Int -> LTerm 'L2 a -> LTerm 'L2 a -> LTerm 'L3 a
+    InfinitelyOftenL3 :: Int -> LTerm 'L2 a -> LTerm 'L3 a
+    StaysAsL3 :: Int -> LTerm 'L2 a -> LTerm 'L3 a
+    deriving (Show)
+
+  fromPreterm = \case
+    PreComplement {} ->
+      -- At the level of modal expressions complement/negation is valid; however, it should be factored by the dual laws
+      -- and distributive laws so we rebuild the expression in rewriting preterms. We could rebuild the expression,
+      -- rewrite, and try again but this is a questionable approach since complement should be here in the first place.
+      Left ComplementInL3
+    PreEventually name terms
+      | PreAlways _ terms' <- terms -> StaysAsL3 name <$> fromPreterm @ 'L2 terms'
+      | otherwise -> EventuallyL3 name <$> fromPreterm @ 'L2 terms
+    PreUpUntil name lhs rhs -> UpUntilL3 name <$> fromPreterm @ 'L2 lhs <*> fromPreterm @ 'L2 rhs
+    PreAlways name terms
+      | PreEventually _ terms' <- terms -> InfinitelyOftenL3 name <$> fromPreterm @ 'L2 terms'
+      | otherwise -> AlwaysL3 name <$> fromPreterm @ 'L2 terms
+    terms -> Left (levelMismatch 3 terms)
+  {-# INLINE fromPreterm #-}
+
+-- | @since 0.1.0.0
+instance SyntaxLevel 'L4 where
+  data LTerm 'L4 a where
+    ModalL4 :: LTerm 'L3 a -> LTerm 'L4 a
+    ConjunctL4 :: LTerm 'L4 a -> LTerm 'L4 a -> LTerm 'L4 a
+    DisjunctL4 :: LTerm 'L4 a -> LTerm 'L4 a -> LTerm 'L4 a
+    deriving (Show)
+
+  fromPreterm = \case
+    terms@PreAlways {} -> ModalL4 <$> fromPreterm @ 'L3 terms
+    terms@PreUpUntil {} -> ModalL4 <$> fromPreterm @ 'L3 terms
+    PreConjunct lhs rhs -> ConjunctL4 <$> fromPreterm @ 'L4 lhs <*> fromPreterm @ 'L4 rhs
+    PreDisjunct lhs rhs -> DisjunctL4 <$> fromPreterm @ 'L4 lhs <*> fromPreterm @ 'L4 rhs
+    terms -> Left (levelMismatch 4 terms)
+  {-# INLINE fromPreterm #-}
+
+-- | Construct a level mismatch exception from the expected level and the term that is mismatched.
+--
+-- @since 0.1.0.0
+levelMismatch :: Int -> Preterm a -> SyntaxException
+levelMismatch level = LevelMismatch level . levelsAsNums
+{-# INLINE levelMismatch #-}
+
+-- | Get a list syntactic levels as 'Num's that the given 'Preterm' can occur at.
+--
+-- @since 0.1.0.0
+levelsAsNums :: Num b => Preterm a -> [b]
+levelsAsNums term = map fromLevel (levelsOf term)
+{-# INLINE levelsAsNums #-}
+
+-- | Get the equivalent 'Num' from a 'Level'.
+--
+-- @since 0.1.0.0
+fromLevel :: Num a => Level -> a
+fromLevel L1 = 1
+fromLevel L2 = 2
+fromLevel L3 = 3
+fromLevel L4 = 4
+{-# INLINE CONLIKE fromLevel #-}
+
+-- | Get a list of syntactic levels the given term can occur.
+--
+-- @since 0.1.0.0
+levelsOf :: Preterm a -> [Level]
+levelsOf = \case
+  PreConst {} -> [L1, L2]
+  PreConjunct {} -> [L2, L4]
+  PreDisjunct {} -> [L2, L4]
+  PreComplement {} -> [L2, L3]
+  PreImplies {} -> [L2]
+  PreNotImplies {} -> [L2]
+  PreAlways {} -> [L3]
+  PreUpUntil {} -> [L3]
+{-# INLINE CONLIKE levelsOf #-}
+
+-- | Extract the unique identifier assigned to a 'LTerm' of 'L3'.
+--
+-- @since 0.1.0.0
+nameFromL3 :: LTerm 'L3 a -> Int
+nameFromL3 = \case
+  AlwaysL3 name _ -> name
+  EventuallyL3 name _ -> name
+  UpUntilL3 name _ _ -> name
+  InfinitelyOftenL3 name _ -> name
+  StaysAsL3 name _ -> name
+{-# INLINE nameFromL3 #-}

--- a/src/Language/Spectacle/Syntax/Modal/Preterm.hs
+++ b/src/Language/Spectacle/Syntax/Modal/Preterm.hs
@@ -29,20 +29,19 @@
 --                 p₂    p₄
 -- @
 --
---
---
 -- @since 0.1.0.0
 module Language.Spectacle.Syntax.Modal.Preterm
   ( Preterm
       ( PreConst,
         PreConjunct,
         PreDisjunct,
-        PreImplies,
-        PreNotImplies,
         PreComplement,
         PreAlways,
         PreUpUntil
       ),
+    pattern PreEventually,
+    pattern PreImplies,
+    pattern PreNotImplies,
     materialize,
     abstract,
     normalizePreterm,
@@ -63,7 +62,7 @@ import Language.Spectacle.Lang
     scope,
     weaken,
   )
-import Language.Spectacle.Syntax.Fresh
+import Language.Spectacle.Syntax.Fresh (Fresh, fresh)
 import Language.Spectacle.Syntax.Logic.Internal (Effect (Complement, Conjunct, Disjunct), Logic (Logic))
 import Language.Spectacle.Syntax.Modal.Internal (Effect (Always, UpUntil), Modal (Modal))
 
@@ -90,8 +89,6 @@ data Preterm a where
   PreConst :: a -> Preterm a
   PreConjunct :: Preterm a -> Preterm a -> Preterm a
   PreDisjunct :: Preterm a -> Preterm a -> Preterm a
-  PreImplies :: Preterm a -> Preterm a -> Preterm a
-  PreNotImplies :: Preterm a -> Preterm a -> Preterm a
   PreComplement :: Preterm a -> Preterm a
   PreAlways :: Int -> Preterm a -> Preterm a
   PreUpUntil :: Int -> Preterm a -> Preterm a -> Preterm a
@@ -106,6 +103,26 @@ data Preterm a where
 -- @since 0.1.0.0
 pattern PreEventually :: Int -> Preterm Bool -> Preterm Bool
 pattern PreEventually name term = PreUpUntil name (PreConst True) term
+
+-- | Pattern synonym for material implication.
+--
+-- @
+-- PreImplies lhs rhs == PreDisjunct (PreComplement lhs) rhs
+-- @
+--
+-- @since 0.1.0.0
+pattern PreImplies :: Preterm a -> Preterm a -> Preterm a
+pattern PreImplies lhs rhs = PreDisjunct (PreComplement lhs) rhs
+
+-- | Pattern synonym for the negation of material implication.
+--
+-- @
+-- PreNotImplies lhs rhs == PreConjunct lhs (PreComplement rhs)
+-- @
+--
+-- @since 0.1.0.0
+pattern PreNotImplies :: Preterm a -> Preterm a -> Preterm a
+pattern PreNotImplies lhs rhs = PreConjunct lhs (PreComplement rhs)
 
 -- | Predicate for whether a given preterm is complement/negation.
 --
@@ -135,15 +152,9 @@ materialize = \case
           rhs' <- runLoom loomReify rhs
           return (PreConjunct lhs' rhs')
         | Disjunct lhs rhs <- eff -> do
-          runLoom loomReify lhs >>= \case
-            PreComplement lhs' -> do
-              rhs' <- runLoom loomReify rhs
-              if isComplement rhs'
-                then return (PreDisjunct lhs' rhs')
-                else return (PreImplies lhs' rhs')
-            lhs' -> do
-              rhs' <- runLoom loomReify rhs
-              return (PreDisjunct lhs' rhs')
+          lhs' <- runLoom loomReify lhs
+          rhs' <- runLoom loomReify rhs
+          return (PreDisjunct lhs' rhs')
         | Complement expr <- eff -> do
           expr' <- runLoom loomReify expr
           return (PreComplement expr')
@@ -179,14 +190,6 @@ abstract preterms =
         let lhs' = fromPreterm lhs
             rhs' = fromPreterm rhs
          in scope (Disjunct lhs' rhs')
-      PreImplies lhs rhs ->
-        let lhs' = scope (Complement (fromPreterm lhs))
-            rhs' = fromPreterm rhs
-         in scope (Disjunct lhs' rhs')
-      PreNotImplies lhs rhs ->
-        let lhs' = fromPreterm lhs
-            rhs' = scope (Complement (fromPreterm rhs))
-         in scope (Conjunct lhs' rhs')
       PreComplement term ->
         let term' = fromPreterm term
          in scope (Complement term')
@@ -259,7 +262,7 @@ normalizePreterm preterm = do
 -- @
 --
 -- @since 0.1.0.0
-rewritePreterm :: Member Fresh effs => Preterm Bool -> Lang ctx effs (Preterm Bool)
+rewritePreterm :: forall ctx effs. Member Fresh effs => Preterm Bool -> Lang ctx effs (Preterm Bool)
 rewritePreterm = \case
   PreConst x -> return (PreConst x)
   PreConjunct lhs rhs
@@ -282,40 +285,21 @@ rewritePreterm = \case
       lhs' <- rewritePreterm lhs
       rhs' <- rewritePreterm rhs
       return (PreDisjunct lhs' rhs')
-  PreImplies lhs rhs -> do
-    lhs' <- rewritePreterm lhs
-    rhs' <- rewritePreterm rhs
-    return (PreImplies lhs' rhs')
-  PreNotImplies lhs rhs -> do
-    lhs' <- rewritePreterm lhs
-    rhs' <- rewritePreterm rhs
-    return (PreNotImplies lhs' rhs')
   PreComplement expr
     | PreComplement expr' <- expr ->
-      -- ¬ (¬ p) ≡ p
       rewritePreterm expr'
     | PreConjunct lhs rhs <- expr -> do
-      -- ¬(p ∧ q) ≡ ¬ p ∨ ¬ q
       lhs' <- rewritePreterm (PreComplement lhs)
       rhs' <- rewritePreterm (PreComplement rhs)
       return (PreDisjunct lhs' rhs')
     | PreDisjunct lhs rhs <- expr -> do
-      -- ¬(p ∨ q) ≡ ¬ p ∧ ¬ q
       lhs' <- rewritePreterm (PreComplement lhs)
       rhs' <- rewritePreterm (PreComplement rhs)
       return (PreConjunct lhs' rhs')
-    | PreImplies lhs rhs <- expr ->
-      -- ¬(p ⇒ q) ≡ ¬(¬p ∧ q) ≡ ¬¬p ∨ ¬q ≡ p ∨ ¬q ≡ p ⇏ q
-      return (PreNotImplies lhs rhs)
-    | PreNotImplies lhs rhs <- expr ->
-      -- ¬(p ⇏ q) ≡ ¬(p ∨ ¬ q) ≡ ¬p ∧ ¬¬q ≡ ¬p ∧ q ≡ p ⇒ q
-      return (PreImplies rhs lhs)
     | PreAlways _ expr' <- expr -> do
-      -- ¬◻p ≡ ◇¬p
       newName <- fresh
       return (PreEventually newName (PreComplement expr'))
     | PreEventually _ expr' <- expr -> do
-      -- ¬◇p ≡ ◻¬p
       newName <- fresh
       return (PreAlways newName (PreComplement expr'))
     | otherwise -> do

--- a/src/Language/Spectacle/Syntax/Prime.hs
+++ b/src/Language/Spectacle/Syntax/Prime.hs
@@ -40,11 +40,11 @@ import Language.Spectacle.Lang
     scope,
   )
 import Language.Spectacle.RTS.Registers
-  ( RuntimeState (RuntimeState, callStack, plains, primes),
+  ( RelationTerm,
+    RuntimeState (RuntimeState, callStack, plains, primes),
     Thunk (Evaluated, Thunk, Unchanged),
     getRegister,
     setRegister,
-    type RelationTermSyntax,
   )
 import Language.Spectacle.Syntax.Env
   ( Env,
@@ -127,7 +127,7 @@ substPrime vars = \case
 substitute ::
   (Members '[Env, NonDet, Error RuntimeException] effs, s # a .| ctx) =>
   Name s ->
-  Lang ctx RelationTermSyntax a ->
+  RelationTerm ctx a ->
   Lang ctx effs a
 substitute name expr = do
   rst <- get

--- a/src/Language/Spectacle/Syntax/Quantifier.hs
+++ b/src/Language/Spectacle/Syntax/Quantifier.hs
@@ -1,10 +1,11 @@
-module Language.Spectacle.Syntax.Quantifier (
-    Quantifier (Quantifier),
+module Language.Spectacle.Syntax.Quantifier
+  ( Quantifier (Quantifier),
     Effect (Forall, Exists),
     forall,
     exists,
     runQuantifier,
-) where
+  )
+where
 
 import Control.Applicative (Alternative (empty))
 import Control.Monad (unless)
@@ -14,66 +15,66 @@ import Data.Foldable (Foldable (toList))
 import Data.Void (absurd)
 
 import Data.Functor.Loom (hoist, runLoom, (~>~))
-import Language.Spectacle.Exception.RuntimeException (
-    QuantifierException (ExistsViolated, ForallViolated),
+import Language.Spectacle.Exception.RuntimeException
+  ( QuantifierException (ExistsViolated, ForallViolated),
     RuntimeException (QuantifierException),
- )
-import Language.Spectacle.Lang (
-    Effect,
+  )
+import Language.Spectacle.Lang
+  ( Effect,
     Lang (Op, Pure, Scoped),
     Member,
     Members,
     decomposeOp,
     decomposeS,
     scope,
- )
-import Language.Spectacle.Syntax.Error (Error, throwE)
+  )
+import Language.Spectacle.Syntax.Error (Error, catchE, throwE)
 import Language.Spectacle.Syntax.NonDet (NonDet, foldMapA, msplit, oneOf)
 import Language.Spectacle.Syntax.Quantifier.Internal (Effect (Exists, Forall), Quantifier (Quantifier))
 
 -- ---------------------------------------------------------------------------------------------------------------------
 
-{- | Universally quantify over some foldable container @f a@. A nondeterministically chosen element in @f a@ will be
- returned so long as the given predicate is 'True' for all elements in the container, otherwise a spectacle exception
- is raised.
-
- @since 0.1.0.0
--}
+-- | Universally quantify over some foldable container @f a@. A nondeterministically chosen element in @f a@ will be
+-- returned so long as the given predicate is 'True' for all elements in the container, otherwise a spectacle exception
+-- is raised.
+--
+-- @since 0.1.0.0
 forall :: (Foldable f, Member Quantifier effs) => f a -> (a -> Lang ctx effs Bool) -> Lang ctx effs Bool
 forall xs p = scope (Forall (toList xs) p)
 {-# INLINE forall #-}
 
-{- | Existential quantification over some foldable constainer @f a@. A nondeterministically chosen element in @f a@
- which satisfies the given predicate will be returned. If there exists no element in the container that satisfies the
- predicate then an exception is raised.
-
- @since 0.1.0.0
--}
+-- | Existential quantification over some foldable constainer @f a@. A nondeterministically chosen element in @f a@
+-- which satisfies the given predicate will be returned. If there exists no element in the container that satisfies the
+-- predicate then an exception is raised.
+--
+-- @since 0.1.0.0
 exists :: (Foldable f, Member Quantifier effs) => f a -> (a -> Lang ctx effs Bool) -> Lang ctx effs Bool
 exists xs p = scope (Exists (toList xs) p)
 {-# INLINE exists #-}
 
 runQuantifier ::
-    Members '[Error RuntimeException, NonDet] effs =>
-    Lang ctx (Quantifier ': effs) Bool ->
-    Lang ctx effs Bool
+  Members '[Error RuntimeException, NonDet] effs =>
+  Lang ctx (Quantifier ': effs) Bool ->
+  Lang ctx effs Bool
 runQuantifier = \case
-    Pure x -> pure x
-    Op op k -> case decomposeOp op of
-        Left other -> Op other (runQuantifier . k)
-        Right bottom -> absurd (coerce bottom)
-    Scoped scoped loom -> case decomposeS scoped of
-        Left other -> Scoped other loom'
-        Right (Forall xs p) -> do
-            b <- oneOf xs >>= runLoom loom' . p
-            unless b (throwE (QuantifierException ForallViolated))
-            return b
-        Right (Exists [] _) -> throwE (QuantifierException ExistsViolated)
-        Right (Exists dom p) -> do
-            let m' = flip foldMapA dom \x -> runLoom loom' (p x) >>= \b -> bool empty (pure b) b
-            msplit m' >>= \case
-                Just _ -> m'
-                Nothing -> throwE (QuantifierException ExistsViolated)
-      where
-        loom' = loom ~>~ hoist runQuantifier
+  Pure x -> pure x
+  Op op k -> case decomposeOp op of
+    Left other -> Op other (runQuantifier . k)
+    Right bottom -> absurd (coerce bottom)
+  Scoped scoped loom -> case decomposeS scoped of
+    Left other -> Scoped other loom'
+    Right (Forall xs p) -> do
+      b <- oneOf xs >>= runLoom loom' . p
+      unless b (throwE (QuantifierException ForallViolated))
+      return b
+    Right (Exists [] _) -> throwE (QuantifierException ExistsViolated)
+    Right (Exists dom p) -> do
+      let m' = flip foldMapA dom \x -> do
+            b <- runLoom loom' (p x) `catchE` (\(_ :: RuntimeException) -> empty)
+            bool empty (pure b) b
+      msplit m' >>= \case
+        Just _ -> m'
+        Nothing -> throwE (QuantifierException ExistsViolated)
+    where
+      loom' = loom ~>~ hoist runQuantifier
 {-# INLINE runQuantifier #-}


### PR DESCRIPTION
This PR glues together all of the effects to provide the user-level syntax for initializing models, defining temporal actions and invariants. It also includes a new graded AST for temporal formula which verifies that the formula a user provided is a not malformed. The graded AST also aids the model checker significantly in the process of checking that a models trace satisfies the invariant associated with it.  

- `Language.Spectacle.AST.Initial`
  - `Closure` was split into `Initial` and `Action` so it can be reused in initial actions with `define`.
     ```haskell
     type SimpleClock =
       '[ "hours" # Int
        , "minutes" # Int
        ]

     myInitialAction :: Initial SimpleClock ()
     myInitialAction = do
       #hours `define` oneOf [0 .. 23]
       #minutes `define` oneOf [0 .. 59]

     ```
- `Language.Spectacle.AST.Action` is the set of effects accessible within temporal actions.
- `Language.Spectacle.AST.Invariant` is the set of effects accessible within invariants.
  - `Language.Spectacle.Syntax.Modal.Graded` is the new graded AST and what the model checker is actually looking at when its running. It prevents users from writing formula such as 
    ```haskell
    myFormula :: Invariant SimpleClock Bool 
    myFormula = always ((<= 23) <$> #hours) /\ ((>= 0) <$> #hours) 
    ```  
    and the model checker is able to emit an exception on its first step if they do. The extra type information also makes traversing formula much easier as its always clear what sort of checks need to be done for a given operation, e.g. disjunction means a different thing in `always p \/ always q` vs `(== 23) <$> #hours \/ (== 59) <$> #minutes`.
   