### PR TITLE
Use GitHub Actions matrix syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,23 +5,13 @@ on:
       - main
   pull_request:
 jobs:
-  build-linux:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.3.4
-        name: Checkout
-      - uses: cachix/install-nix-action@v12
-        name: Install Nix
-        with:
-          nix_path: nixpkgs=./nix/pkgs.nix
-      - uses: cachix/cachix-action@v8
-        name: Set up Cachix
-        with:
-          name: awakesecurity
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix-build --attr spectacle
-  build-macos:
-    runs-on: macos-10.15
+  build:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-10.15
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2.3.4
         name: Checkout


### PR DESCRIPTION
@lambdadog told me about GitHub Actions' [matrix syntax][1], which helps reduce boilerplate.

[1]: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
