### PR TITLE
Apply temporal formula to initial worlds 

### DIFF
--- a/spectacle.cabal
+++ b/spectacle.cabal
@@ -147,6 +147,7 @@ test-suite unit-tests
   other-modules:
       Spectacle.Syntax.Modal
     , Spectacle.Syntax.Modal.Properties
+    , Spectacle.Checker.VacuousFormula
 
   build-depends:
       spectacle

--- a/src/Language/Spectacle/Checker/Model.hs
+++ b/src/Language/Spectacle/Checker/Model.hs
@@ -66,8 +66,8 @@ import Language.Spectacle.Checker.Model.MCError
         MCFormulaError,
         MCFormulaRuntimeError,
         MCImpasseError,
-        MCStutterError,
-        MCInternalError
+        MCInternalError,
+        MCStutterError
       ),
     PropertyKind (AlwaysPropK, EventuallyPropK, UpUntilPropK),
     StutterKind (FiniteStutterK, InfiniteStutterK),
@@ -284,10 +284,9 @@ checkAlways :: forall ctx. Step ctx -> Int -> Maybe SrcLoc -> Term Bool -> Model
 checkAlways step name srcLoc e = do
   result <- interpretFormula step e
   truthCoverage . stepTruth step name .= result
-
-  unless result (throwError [MCFormulaError step srcLoc AlwaysPropK])
-
-  return result
+  if result
+    then return result
+    else throwError [MCFormulaError step srcLoc AlwaysPropK]
 {-# INLINE checkAlways #-}
 
 -- | @'checkEventually' step name e@ checks a formula @eventually e@ identified by @name@ for the model-step @step@.

--- a/src/Language/Spectacle/Interaction/Render.hs
+++ b/src/Language/Spectacle/Interaction/Render.hs
@@ -295,7 +295,7 @@ renderLineViewDoc :: Int -> String -> IO (Doc AnsiStyle)
 renderLineViewDoc lineNumber filePath = do
   srcLines <- lines <$> readFile filePath
   let line = srcLines !! (lineNumber - 1)
-      padding = length (show lineNumber) + 1 -- lineNumber
+      padding = length (show lineNumber) + 1
   return . vsep $
     [ indent padding (annotate (bold <> color Red) "│")
     , annotate bold (pretty lineNumber) <+> annotate (bold <> color Red) "│" <+> pretty line

--- a/src/Language/Spectacle/Interaction/Render.hs
+++ b/src/Language/Spectacle/Interaction/Render.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NegativeLiterals #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Language.Spectacle.Interaction.Render
@@ -175,7 +174,7 @@ renderMCStutterErrorDoc step Nothing propK stutterK = do
         <> hardline
     ]
 renderMCStutterErrorDoc step (Just srcLoc) propK stutterK = do
-  let padding = countDigits (srcLocStartLine srcLoc)
+  let padding = length (show (srcLocStartLine srcLoc))
   lineView <- renderLineViewDoc (srcLocStartLine srcLoc) (srcLocFile srcLoc)
   return . vsep $
     [ annotate (bold <> color White) (fileHeadingDoc (srcLocFile srcLoc) <> ":") <+> errorDoc
@@ -207,7 +206,7 @@ renderMCFormulaErrorDoc step Nothing propK =
         <> hardline
     ]
 renderMCFormulaErrorDoc step (Just srcLoc) propK = do
-  let padding = countDigits (srcLocStartLine srcLoc)
+  let padding = length (show (srcLocStartLine srcLoc))
   lineView <- renderLineViewDoc (srcLocStartLine srcLoc) (srcLocFile srcLoc)
   return . vsep $
     [ annotate (bold <> color White) (fileHeadingDoc (srcLocFile srcLoc) <> ":") <+> errorDoc
@@ -236,7 +235,7 @@ renderMCStrongLivenessErrorDoc = \case
         <> hardline
         <> indent 2 "could not satisfy liveness properties with strong fairness constraint"
   Just srcLoc -> do
-    let padding = countDigits (srcLocStartLine srcLoc)
+    let padding = length (show (srcLocStartLine srcLoc))
     lineView <-
       renderLineViewDoc
         (srcLocStartLine srcLoc)
@@ -296,7 +295,7 @@ renderLineViewDoc :: Int -> String -> IO (Doc AnsiStyle)
 renderLineViewDoc lineNumber filePath = do
   srcLines <- lines <$> readFile filePath
   let line = srcLines !! (lineNumber - 1)
-      padding = countDigits lineNumber + 1
+      padding = length (show lineNumber) + 1 -- lineNumber
   return . vsep $
     [ indent padding (annotate (bold <> color Red) "│")
     , annotate bold (pretty lineNumber) <+> annotate (bold <> color Red) "│" <+> pretty line
@@ -398,10 +397,3 @@ finiteStutterNote = "Occurring in a stutter-step"
 cyclicBehaviorNote :: Doc AnsiStyle
 cyclicBehaviorNote = "In the cyclic behavior"
 {-# INLINE CONLIKE cyclicBehaviorNote #-}
-
--- ----------------------------------------------------------------------------------------------------------------------
-
-countDigits :: Int -> Int
-countDigits 0 = 1
-countDigits n = round (logBase (10 :: Double) (fromIntegral (abs n))) + 1
-{-# INLINE countDigits #-}

--- a/test/unit-tests/Main.hs
+++ b/test/unit-tests/Main.hs
@@ -1,5 +1,8 @@
+module Main (main) where
+
 import Test.Tasty (defaultMain, testGroup)
 
+import qualified Spectacle.Checker.VacuousFormula
 import qualified Spectacle.Syntax.Modal
 
 main :: IO ()
@@ -8,4 +11,5 @@ main =
     testGroup
       "unit tests"
       [ Spectacle.Syntax.Modal.tests
+      , Spectacle.Checker.VacuousFormula.tests
       ]

--- a/test/unit-tests/Spectacle/Checker/VacuousFormula.hs
+++ b/test/unit-tests/Spectacle/Checker/VacuousFormula.hs
@@ -1,0 +1,62 @@
+-- | Unit tests on vacuous temporal formula.
+--
+-- @since 0.1.0.0
+module Spectacle.Checker.VacuousFormula
+  ( tests,
+  )
+where
+
+import Hedgehog (Property, failure, property, success)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Language.Spectacle (Action, Initial, Invariant, always, modelCheck, unfair)
+import Language.Spectacle.Checker.Metrics (ModelMetrics)
+import Language.Spectacle.Checker.Model.MCError (MCError)
+import Language.Spectacle.Specification (Specification (Specification))
+
+-- ---------------------------------------------------------------------------------------------------------------------
+
+type VacuousSpec = '[]
+
+specInit :: Initial VacuousSpec ()
+specInit = return ()
+
+specNext :: Action VacuousSpec Bool
+specNext = return True
+
+-- | Test case ensuring that the formula @return False@ fails at initial world generation, in reference to the issue:
+-- <https://github.com/awakesecurity/spectacle/issues/26>
+testAlwaysVacuousProp :: Property
+testAlwaysVacuousProp = property do
+  case alwaysCheckSpec of
+    Left _ -> success
+    Right _ -> failure
+  where
+    alwaysSpecProp :: Invariant VacuousSpec Bool
+    alwaysSpecProp = always (return False)
+
+    alwaysCheckSpec :: Either [MCError VacuousSpec] ModelMetrics
+    alwaysCheckSpec = modelCheck (Specification specInit specNext alwaysSpecProp Nothing unfair)
+
+-- | Test case ensuring that the formula @always (return False)@ fails at initial world generation, in reference to the
+-- issue: <https://github.com/awakesecurity/spectacle/issues/26>
+testVacuousProp :: Property
+testVacuousProp = property do
+  case checkSpec of
+    Left _ -> success
+    Right _ -> failure
+  where
+    specProp :: Invariant VacuousSpec Bool
+    specProp = always (return False)
+
+    checkSpec :: Either [MCError VacuousSpec] ModelMetrics
+    checkSpec = modelCheck (Specification specInit specNext specProp Nothing unfair)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Checker.VacuousFormula"
+    [ testProperty "vacuous formula (always false) is violated." testAlwaysVacuousProp
+    , testProperty "vacuous formula (false) is violated" testVacuousProp
+    ]


### PR DESCRIPTION
This PR fixes issue #26, a bug where the model's temporal formula was being checked for the initial worlds.