### PR TITLE
Enable dual trace and checking mode in CLI

### DIFF
--- a/spectacle.cabal
+++ b/spectacle.cabal
@@ -1,7 +1,7 @@
 cabal-version:       3.0
 
 name:                spectacle
-version:             1.0.0
+version:             1.0.1
 category:            Testing, Concurrency
 synopsis:            Embedded specification language & model checker in Haskell.
 description:
@@ -41,7 +41,6 @@ common common
     -Wmissing-home-modules
     -Wredundant-constraints
     -fshow-warning-groups
-    -Wmissing-import-lists
 
   build-depends:
       base           >= 4.14 && < 4.18

--- a/src/Language/Spectacle/Interaction.hs
+++ b/src/Language/Spectacle/Interaction.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 -- |
@@ -11,57 +12,89 @@
 -- CLI interaction.
 --
 -- @since 1.0.0
-module Language.Spectacle.Interaction
-  ( -- * CLI
-    interaction,
-    handleInteraction,
-  )
-where
+module Language.Spectacle.Interaction (
+  -- * CLI
+  interaction,
+  handleInteraction,
+) where
 
-import Control.Monad (when)
+import Control.Monad (unless, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (asks)
 import Data.Either (isRight)
-import Data.Hashable (Hashable)
-
 import Data.Functor.Tree (Tree)
+import Data.Hashable (Hashable)
 import Data.Type.Rec (HasDict)
 import Data.World (World)
-import Language.Spectacle.Interaction.CLI (CLI, ContextCLI (ctxOpts), cliPutDoc, cliResultDoc, runCLI)
+import Language.Spectacle.Interaction.CLI (CLI)
+import Language.Spectacle.Interaction.CLI qualified as CLI
 import Language.Spectacle.Interaction.Diagram (diagramFull, runDiagram)
-import Language.Spectacle.Interaction.Options (OptsCLI (optsLogGraph, optsOnlyTrace))
-import qualified Language.Spectacle.Interaction.Options as Opts
+import Language.Spectacle.Interaction.Options qualified as Options
+import Language.Spectacle.Interaction.Options qualified as Opts
 import Language.Spectacle.Interaction.Paths (toPointSet)
 import Language.Spectacle.Model (modelcheck, modeltrace)
 import Language.Spectacle.Model.ModelError (ModelError, ppModelError)
 import Language.Spectacle.Specification (Specification)
+import Prettyprinter (Doc)
+import Prettyprinter qualified as Doc
+import Prettyprinter.Render.Terminal (AnsiStyle, Color (..))
+import Prettyprinter.Render.Terminal qualified as Doc
 
-import Prettyprinter (line)
+--------------------------------------------------------------------------------
 
--- ---------------------------------------------------------------------------------------------------------------------
-
-interaction :: (HasDict Eq ctx, HasDict Hashable ctx, HasDict Show ctx) => Specification ctx acts form -> IO ()
+interaction ::
+  forall ctx acts form.
+  (HasDict Eq ctx, HasDict Hashable ctx, HasDict Show ctx) =>
+  Specification ctx acts form ->
+  IO ()
 interaction spec = do
-  opts <- Opts.execOptsCLI
-  result <-
-    if optsOnlyTrace opts
-      then modeltrace spec
-      else modelcheck spec
+  options <- Opts.getOptionsCLI
 
-  runCLI (handleInteraction result) opts
+  CLI.runCLI options do
+    if Options.run_check options
+      then do
+        checkResult <- liftIO (modelcheck spec)
+        handleInteraction checkResult
 
-handleInteraction :: HasDict Show ctx => Either (ModelError ctx) [Tree (World ctx)] -> CLI ()
-handleInteraction result =
-  let status = isRight result
-   in case result of
-        Left err -> do
-          cliPutDoc =<< cliResultDoc status
-          cliPutDoc (ppModelError err)
-          cliPutDoc line
-        Right trees -> do
-          isLogging <- asks (optsLogGraph . ctxOpts)
-          when isLogging do
-            let pointSet = foldMap toPointSet trees
-            diagramDoc <- liftIO (runDiagram $ diagramFull pointSet)
-            cliPutDoc (diagramDoc <> line)
-          cliPutDoc =<< cliResultDoc status
+        when (Options.run_trace options) do
+          traceResult <- liftIO (modeltrace spec)
+          handleInteraction traceResult
+
+        modesDoc <- CLI.docRunModes (isRight checkResult)
+        CLI.cliPutDoc (modesDoc <> Doc.line)
+      else
+        if Options.run_trace options
+          then do
+            result <- liftIO (modeltrace spec)
+            modesDoc <- CLI.docRunModes (isRight result)
+
+            handleInteraction result
+
+            unless (Options.log_diagram options) do
+              CLI.cliPutDoc (docWarn ("running " <> style "--trace" <> " without enabling " <> style "--diagram"))
+
+            CLI.cliPutDoc (modesDoc <> Doc.line)
+          else do
+            CLI.cliPutDoc (docWarn "nothing to do!")
+  where
+    docWarn :: Doc AnsiStyle -> Doc AnsiStyle
+    docWarn doc = style "warning: " <> doc <> Doc.line
+
+    style :: Doc AnsiStyle -> Doc AnsiStyle
+    style = Doc.annotate (Doc.color Blue)
+
+handleInteraction ::
+  HasDict Show ctx =>
+  Either (ModelError ctx) [Tree (World ctx)] ->
+  CLI ()
+handleInteraction result = do
+  case result of
+    Left err -> do
+      CLI.cliPutDoc (ppModelError err <> Doc.line)
+    Right trees -> do
+      options <- asks CLI.ctx_options
+
+      when (Options.log_diagram options) do
+        let pointSet = foldMap toPointSet trees
+        diagramDoc <- liftIO (runDiagram $ diagramFull pointSet)
+        CLI.cliPutDoc (diagramDoc <> Doc.line)

--- a/src/Language/Spectacle/Interaction/Options.hs
+++ b/src/Language/Spectacle/Interaction/Options.hs
@@ -45,7 +45,7 @@ defineStringOption :: IsString s => [Mod OptionFields s] -> Parser s
 defineStringOption = Options.strOption . fold
 
 defineSwitchOption' :: [Mod FlagFields Bool] -> Parser Bool
-defineSwitchOption' = Options.flag False True . fold
+defineSwitchOption' = Options.switch . fold
 
 -- OptionsCLI ------------------------------------------------------------------
 

--- a/src/Language/Spectacle/Interaction/Options.hs
+++ b/src/Language/Spectacle/Interaction/Options.hs
@@ -7,162 +7,206 @@
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)
--- 
+--
 -- Command-line interface options.
 --
 -- @since 1.0.0
-module Language.Spectacle.Interaction.Options
-  ( -- * CLI Options
-    OptsCLI (OptsCLI),
-    optsLogGraph,
-    optsOnlyTrace,
-    optsLogOutput,
+module Language.Spectacle.Interaction.Options (
+  -- * OptionsCLI
+  OptionsCLI (..),
 
-    -- * CLI Parser
-    execOptsCLI,
-    parseOptsCLI,
+  -- * OutputOption
+  OutputOption (..),
 
-    -- ** "only-trace" option
-    pOnlyTrace,
+  -- ** I/O
+  openOutput,
 
-    -- ** "log" option
-    pLogGraph,
+  -- * CLI Options
+  getOptionsCLI,
 
-    -- ** "output" Option
-    OutputOpt (OptStdout, OptPath),
-    isStdout,
-    handleFrom,
-    pOutputOpt,
-    pOutputPath,
-  )
-where
+  -- ** Parsers
+  parseOptionsCLI,
+  parseDiagramOption,
+  parseNoCheckOption,
+  parseRunTraceOption,
+  parseOutputOption,
+) where
 
-import Control.Applicative (Alternative ((<|>)), (<**>))
-import Options.Applicative
-  ( Parser,
-    customExecParser,
-    help,
-    helper,
-    idm,
-    info,
-    long,
-    metavar,
-    prefs,
-    short,
-    showHelpOnEmpty,
-    strOption,
-    switch,
-  )
-import System.IO (BufferMode (LineBuffering), Handle, IOMode (ReadWriteMode), hSetBuffering, openFile, stdout)
+import Data.Foldable (fold)
+import Data.String (IsString (..))
+import Options.Applicative (FlagFields, Mod, OptionFields, Parser)
+import Options.Applicative qualified as Options
+import System.IO (Handle)
+import System.IO qualified as System
 
--- ---------------------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
--- | 'OptsCLI' is a record command-line options for configuring the model checker.
+defineStringOption :: IsString s => [Mod OptionFields s] -> Parser s
+defineStringOption = Options.strOption . fold
+
+defineSwitchOption' :: [Mod FlagFields Bool] -> Parser Bool
+defineSwitchOption' = Options.flag False True . fold
+
+-- OptionsCLI ------------------------------------------------------------------
+
+-- | 'OptionsCLI' is a record storing all command-line options that can be used
+-- to configure the model checker's behavior.
 --
 -- @since 1.0.0
-data OptsCLI = OptsCLI
-  { -- | Should the state diagram be drawn?
-    optsLogGraph :: Bool
-  , -- | Should the model checker only trace the states of a specification, without checking temporal properties?
-    optsOnlyTrace :: Bool
-  , -- | The output path for logs produced by CLI.
-    optsLogOutput :: OutputOpt
+data OptionsCLI = OptionsCLI
+  { log_diagram :: Bool
+  -- ^ Should the state diagram be drawn?
+  --
+  -- @since 1.0.0
+  , run_check :: Bool
+  -- ^ Should the model checker check temporal properties?
+  --
+  -- @since 1.0.1
+  , run_trace :: Bool
+  -- ^ Should the model checker trace the state space of a specification?
+  --
+  -- @since 1.0.1
+  , output_path :: OutputOption
+  -- ^ The output path for logs produced by CLI.
+  --
+  -- @since 1.0.0
   }
   deriving (Eq, Show)
 
--- | 'execOptsCLI' runs the command-line options parser.
+-- OutputOption ----------------------------------------------------------------
+
+-- | The 'OutputOption' datatype is the sum of all filepaths that can be
+-- specified from Spectacles command-line options.
 --
 -- @since 1.0.0
-execOptsCLI :: IO OptsCLI
-execOptsCLI =
-  let option = info (parseOptsCLI <**> helper) idm
-      config = prefs showHelpOnEmpty
-   in customExecParser config option
+data OutputOption
+  = -- | The output path representing @('System.stderr' :: 'Handle')@.
+    --
+    -- @since 1.0.1
+    OutputStderr
+  | -- | The output path representing @('System.stdout' :: 'Handle')@.
+    --
+    -- @since 1.0.0
+    OutputStdout
+  | -- | Output path for an arbitrary 'FilePath'.
+    --
+    -- @since 1.0.0
+    OutputPath FilePath
+  deriving (Eq, Ord, Show)
 
--- | 'parseOptsCLI' is the parses command-line options into an 'OptsCLI'.
+-- | @since 1.0.1
+instance IsString OutputOption where
+  fromString str
+    | str == "stderr" = OutputStderr
+    | str == "stdout" = OutputStdout
+    | otherwise = OutputPath str
+  {-# INLINE CONLIKE fromString #-}
+
+-- | @since 1.0.1
+instance Read OutputOption where
+  readsPrec _ str = [(fromString str, str)]
+  {-# INLINE readsPrec #-}
+
+-- OutputOption - I/O ----------------------------------------------------------
+
+-- | Similar to 'System.openFile', but instead obtains a write-only file
+-- 'Handle' from a 'OutputOption'.
 --
--- @since 1.0.0
-parseOptsCLI :: Parser OptsCLI
-parseOptsCLI =
-  OptsCLI
-    <$> pLogGraph
-    <*> pOnlyTrace
-    <*> pOutputOpt
+-- @since 1.0.1
+openOutput :: OutputOption -> IO Handle
+openOutput OutputStderr = pure System.stderr
+openOutput OutputStdout = pure System.stdout
+openOutput (OutputPath filepath) = System.openFile filepath System.WriteMode
 
--- ---------------------------------------------------------------------------------------------------------------------
+-- CLI Options -----------------------------------------------------------------
 
--- | CLI parser that consumes the "only-trace" flag.
+-- | Similar 'System.getArgs', but parses all program arguments with the
+-- 'parseOptionsCLI' parser.
 --
--- @since 1.0.0
-pOnlyTrace :: Parser Bool
-pOnlyTrace =
-  switch
-    ( long "only-trace"
-        <> short 't'
-        <> help "Disable property checking and only trace a specification"
-    )
+-- @since 1.0.1
+getOptionsCLI :: IO OptionsCLI
+getOptionsCLI =
+  Options.customExecParser
+    (Options.prefs Options.showHelpOnEmpty)
+    (Options.info (Options.helper <*> parseOptionsCLI) Options.idm)
 
--- ---------------------------------------------------------------------------------------------------------------------
+-- CLI Options - Parsers -------------------------------------------------------
 
--- | CLI parser that consumes the "log" flag.
+-- | The 'parseOptionsCLI' function parses each of the CLI options, and collects
+-- each of the parsed values into a 'OptionsCLI' record.
 --
--- @since 1.0.0
-pLogGraph :: Parser Bool
-pLogGraph =
-  switch
-    ( long "log"
-        <> short 'l'
-        <> help "Graph the model checker trace"
-    )
+-- @since 1.0.1
+parseOptionsCLI :: Parser OptionsCLI
+parseOptionsCLI =
+  OptionsCLI
+    <$> parseDiagramOption
+    <*> (not <$> parseNoCheckOption)
+    <*> parseRunTraceOption
+    <*> parseOutputOption
 
--- ---------------------------------------------------------------------------------------------------------------------
-
--- | CLI option datatype holding either a filepath to emit model checker logs to.
+-- | Parse the "--no-check" CLI flag. Enabling the "--no-check" flag will
+-- disable property checking in the model checker.
 --
--- * @'OutputPath' str@ is a filepath to write logs to.
--- * 'OutputStdout' represents stdout as the chosen output location.
+-- __Default:__ @('True' :: 'Bool')@
 --
--- @since 1.0.0
-data OutputOpt
-  = OptStdout
-  | OptPath FilePath
-  deriving (Eq, Show)
+-- @since 1.0.1
+parseNoCheckOption :: Parser Bool
+parseNoCheckOption =
+  defineSwitchOption'
+    [ Options.long "no-check"
+    , Options.help "Disable property checking."
+    ]
 
--- | Is the output buffer stdout?
+-- | Parse the @"--trace"@ CLI flag. Enabling the @"--trace"@ flag enables
+-- "trace mode" for model checker. If the @"--trace"@ flag is combined with the
+-- @"--no-check"@ flag, the model checker  will only enumerate the states that
+-- are reachable by a specification's actions without performing property checks
+-- on the states reached.
 --
--- @since 1.0.0
-isStdout :: OutputOpt -> Bool
-isStdout opt = opt == OptStdout
-
--- | @'handleFrom' opt@ will extract the file hand from the given 'OutputOpt' @opt@.
+-- __Default:__ @('False' :: 'Bool')@
 --
--- @since 1.0.0
-handleFrom :: OutputOpt -> IO Handle
-handleFrom opt = do
-  handle <- case opt of
-    OptStdout -> pure stdout
-    OptPath fp -> openFile fp ReadWriteMode
+-- @since 1.0.1
+parseRunTraceOption :: Parser Bool
+parseRunTraceOption =
+  defineSwitchOption'
+    [ Options.long "trace"
+    , Options.short 't'
+    , Options.help "Enable tracing the specification's state space."
+    ]
 
-  hSetBuffering handle LineBuffering
-  pure handle
-
--- | CLI parser that consumes the result of 'pOutputPath' if an output path is provided, otherwise 'OutputStd' is
--- returned by default and logs will be written to stdout.
+-- | Parse the @"--diagram"@ CLI flag. If the @"--trace"@ flag is enabled, then
+-- enabling the @"--diagram"@ flag will render the specification's state space
+-- as a diagram and write it to output path specified by the "--output" option.
 --
--- @since 1.0.0
-pOutputOpt :: Parser OutputOpt
-pOutputOpt = pOutputPath <|> pure OptStdout
-
--- | CLI parser that consumes a filepath to emit logs to.
+-- __Default:__ @('False' :: 'Bool')@
 --
--- @since 1.0.0
-pOutputPath :: Parser OutputOpt
-pOutputPath = OptPath <$> parser
-  where
-    parser =
-      strOption
-        ( long "output"
-            <> short 'o'
-            <> metavar "OUTPUT"
-            <> help "The log output path"
-        )
+-- @since 1.0.1
+parseDiagramOption :: Parser Bool
+parseDiagramOption =
+  defineSwitchOption'
+    [ Options.long "diagram"
+    , Options.help "Output a diagram of the model checker trace."
+    ]
+
+-- | Parse the @"--output"@ CLI option.
+--
+--   * If @"--output stderr"@ is passed, then all logs and output from the model
+--     checker will be rendered to @('System.stderr' :: 'Handle')@.
+--
+--   * If @"--output stdout"@ is passed, then all logs and output from the model
+--     checker will be rendered to @('System.stdout' :: 'Handle')@.
+--
+--   * Otherwise, any argument given to the @"--output"@ option is assumed to be
+--     a filepath, and all output will be rendered to a file at that location.
+--
+-- __Default:__ @('System.stdout' :: 'Handle')@
+--
+-- @since 1.0.1
+parseOutputOption :: Parser OutputOption
+parseOutputOption =
+  defineStringOption
+    [ Options.long "output"
+    , Options.short 'o'
+    , Options.help "The log output path"
+    , Options.value OutputStdout
+    ]


### PR DESCRIPTION
This PR makes changes to enable tracing-mode and checking-mode runs of the model checker within the same interactive session. Previously, an interaction session could only run a single model checker run in either tracing or checking mode, depending on the CLI arguments specified. These changes enable trace-only mode, check-only mode, and a dual trace+check mode.

- Additional code changes were made to improve documentation and naming. 
- Changes what information is emitted from interactive sessions were made:
  - `success` is no longer written to output if the model checker is running in trace-only mode to help avoid confusing traces with passing property checks.
  - Interactive sessions will now warn users if `--no-check` is enabled without `--trace`. 
 
    ![image](https://user-images.githubusercontent.com/8868893/211645820-ccd66162-90af-4cf6-91a5-ac1646302848.png)
  - Interactive sessions will now warn users if `--trace` is enabled without `--diagram`.
    
    ![image](https://user-images.githubusercontent.com/8868893/211645712-93be3345-72c9-493c-8241-4bd4f250ee71.png)

  - Running the model checker from an interactive session in both tracing and checking mode now renders unique a status indicator to output.
    
    ![image](https://user-images.githubusercontent.com/8868893/211647701-226abaa5-dd83-4700-ba65-0f163fc28aac.png)


 