### PR TITLE
Support GHC 9.8

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666057921,
-        "narHash": "sha256-VpQqtXdj6G7cH//SvoprjR7XT3KS7p+tCVebGK1N6tE=",
+        "lastModified": 1744868846,
+        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "88eab1e431cabd0ed621428d8b40d425a07af39f",
+        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
         "type": "github"
       },
       "original": {
@@ -35,6 +38,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
         system.aarch64-darwin
       ];
 
-      ghcVersion = "ghc924";
+      ghcVersion = "ghc92";
 
     in flake-utils.lib.eachSystem systems (system:
       let

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
         system.aarch64-darwin
       ];
 
-      ghcVersion = "ghc92";
+      ghcVersion = "ghc98";
 
     in flake-utils.lib.eachSystem systems (system:
       let

--- a/nix/overlays/haskell.nix
+++ b/nix/overlays/haskell.nix
@@ -7,7 +7,6 @@ final: prev:
     packages = prev.haskell.packages // {
       "${ghcVersion}" = prev.haskell.packages."${ghcVersion}".extend 
         (final-haskell-packages: prev-haskell-packages: {
-          logict = prev-haskell-packages.logict_0_8_0_0;
           spectacle = final-haskell-packages.callCabal2nix "spectacle" ../../. { };
         });
     };

--- a/spectacle.cabal
+++ b/spectacle.cabal
@@ -43,7 +43,7 @@ common common
     -fshow-warning-groups
 
   build-depends:
-      base           >= 4.14 && < 4.18
+      base           >= 4.14 && < 4.20
     , comonad        >= 5
     , containers     >= 0.6
     , hashable       >= 1.3.4.0


### PR DESCRIPTION
I've tested the build with 
- 9.2.8
- 9.4.8
- 9.6.6
- 9.8.4

Since GHC 9.4 there is a warning that `forall` will become reserved. This started failing in 9.10, hence I kept `base<4.20`
```
spectacle> src/Language/Spectacle/Syntax/Quantifier.hs:60:1: warning: [-Wforall-identifier (in -Wdefault)]
spectacle>     The use of ‘forall’ as an identifier
spectacle>     will become an error in a future GHC release.
spectacle>     Suggested fix:
spectacle>       Consider using another name, such as
spectacle>       ‘forAll’, ‘for_all’, or ‘forall_’.
spectacle>    |
spectacle> 60 | forall xs = forallIntro (toList xs)
```

Since GHC 9.6 there is a warning about redundant imports, I've kept them for compatibility
```
The import of ‘Control.Applicative’ is redundant
```